### PR TITLE
Added DoclingExtract 

### DIFF
--- a/DoclingExtract/DoclingExtract.ipynb
+++ b/DoclingExtract/DoclingExtract.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "729334ed-cffb-4edb-9fec-afa778e36700",
+   "metadata": {},
+   "source": [
+    "# Document Extraction with Docling\n",
+    "\n",
+    "This notebook demonstrates an end-to-end pipeline for extracting structured information from PDF and image documents using the **Docling** framework. It automatically detects and extracts:\n",
+    "\n",
+    "- Tables (as structured CSV files)\n",
+    "- Figures (as cropped PNGs)\n",
+    "- Document text (as clean Markdown)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Set Up Your Environment\n",
+    "\n",
+    "Before running the notebook, it's recommended to create a **virtual environment**, Navigate to the project directory where you want to set up the environment:\n",
+    "\n",
+    "```bash\n",
+    "python -m venv --system-site-packages docenv\n",
+    "source docenv/bin/activate\n",
+    "pip install ipykernel\n",
+    "python -m ipykernel install --user --name=docenv --display-name \"Python (Docling)\"\n",
+    "\n",
+    "```\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Ensure that you are in the directory where the Jupyter Notebook and virtual environment is located.\n",
+    "Load the Python (Docling) kernel before running the following cells.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d415622f-3822-425b-98c4-f7ce03baa23f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!. ./docenv/bin/activate; pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df2b907-bc66-4176-a8e2-2fce5adaa0cb",
+   "metadata": {},
+   "source": [
+    "## Import Libraries\n",
+    "\n",
+    "This cell imports all required libraries for PDF and image handling, table and figure processing, and data visualization. It includes:\n",
+    "- `os`, `pathlib`, and `glob` for file management,\n",
+    "- `pandas` and `matplotlib` for data display and plotting,\n",
+    "- `PIL.Image` and `fitz` (PyMuPDF) for rendering images from PDF pages,\n",
+    "- Core Docling components for document parsing.\n",
+    "\n",
+    "These are necessary to run the extraction pipeline using Docling's PDF processing tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "065da944-ab89-4e14-9813-b97117adf541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set custom directories for cache\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "\n",
+    "def set_env_with_cache_dir(env_var_name: str, subdir: str):\n",
+    "    base_cache = os.path.join(os.getcwd(), \".cache\")\n",
+    "    full_path = os.path.join(base_cache, subdir)\n",
+    "    os.environ[env_var_name] = full_path\n",
+    "    os.makedirs(full_path, exist_ok=True)\n",
+    "    print(f\"{env_var_name}={full_path}\")\n",
+    "\n",
+    "set_env_with_cache_dir(\"PIP_CACHE_DIR\", \"pip_cache\")\n",
+    "set_env_with_cache_dir(\"HF_HOME\", \"hf_cache\")\n",
+    "set_env_with_cache_dir(\"EASYOCR_MODULE_PATH\", \"easyocr_cache\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52e71a4a-39fa-45a2-8b6b-108b8615381d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from PIL import Image\n",
+    "import fitz  \n",
+    "import glob\n",
+    "import time \n",
+    "import hashlib\n",
+    "\n",
+    "from docling.datamodel.base_models import InputFormat\n",
+    "from docling.document_converter import DocumentConverter, PdfFormatOption\n",
+    "from docling.datamodel.pipeline_options import PdfPipelineOptions, TableFormerMode\n",
+    "from docling_core.types.doc.document import PictureItem\n",
+    "from docling.datamodel.accelerator_options import AcceleratorOptions, AcceleratorDevice\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fc19160-1b99-4b43-87f4-b0475dfaa986",
+   "metadata": {},
+   "source": [
+    "## Display the Input File (PDF or Image)\n",
+    "\n",
+    "This function displays the first page of a given file.\n",
+    "- For PDFs: Converts the first page to a high-resolution image using `fitz` and renders it with `matplotlib`.\n",
+    "- For images: Directly opens and displays them.\n",
+    "- Unsupported formats raise an error.\n",
+    "\n",
+    "This is useful for visually confirming the input document before running the extraction pipeline.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25a55056-41e0-46bd-8373-5a7f2ac7c4fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_file(file_path):\n",
+    "    file_extension = os.path.splitext(file_path)[1].lower()\n",
+    "    if file_extension == '.pdf':\n",
+    "        doc = fitz.open(file_path)\n",
+    "        for page_num in range(len(doc)):\n",
+    "            page = doc.load_page(page_num)\n",
+    "            pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))\n",
+    "            image = Image.frombytes(\"RGB\", [pix.width, pix.height], pix.samples)\n",
+    "            plt.figure(figsize=(16, 12))\n",
+    "            plt.imshow(image)\n",
+    "            plt.axis('off')\n",
+    "            plt.show()\n",
+    "            break\n",
+    "        doc.close()\n",
+    "    elif file_extension in ['.jpg', '.jpeg', '.png', '.bmp', '.tiff']:\n",
+    "        image = Image.open(file_path)\n",
+    "        plt.figure(figsize=(16, 12))\n",
+    "        plt.imshow(image)\n",
+    "        plt.axis('off')\n",
+    "        plt.show()\n",
+    "    else:\n",
+    "        raise ValueError(\"Unsupported file type.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef6cb3b-4320-49e2-8a60-995b8dce5cd2",
+   "metadata": {},
+   "source": [
+    "### Compute File Hash\n",
+    "\n",
+    "This helper function computes a SHA-256 hash of the input PDF or image file.\n",
+    "\n",
+    "• Used to detect whether a file has changed since it was last processed  \n",
+    "• Called by `needs_reprocessing()` and inside the extraction function to store metadata\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "383fff92-d6bd-4329-af31-8904c1013fbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_file_hash(path):\n",
+    "    hasher = hashlib.sha256()\n",
+    "    with open(path, \"rb\") as f:\n",
+    "        while chunk := f.read(8192):\n",
+    "            hasher.update(chunk)\n",
+    "    return hasher.hexdigest()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bd09f3a-ee68-4471-8f11-c789804fd217",
+   "metadata": {},
+   "source": [
+    "### Check If File Needs Reprocessing\n",
+    "\n",
+    "This function checks whether a file needs to be reprocessed based on:\n",
+    "\n",
+    "• A force flag (File will always be reprocessed if this is set to True\n",
+    "• Absence of a previously saved hash file  \n",
+    "• A mismatch between the current and stored file hash\n",
+    "\n",
+    "It ensures that already processed documents are not reprocessed, avoiding redundant work.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d14ab0e7-24ab-4834-b275-725c905c6e55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def needs_reprocessing(input_path, metadata_path, force=False):\n",
+    "    if force:\n",
+    "        return True\n",
+    "    if not metadata_path.exists():\n",
+    "        return True\n",
+    "    current_hash = compute_file_hash(input_path)\n",
+    "    with open(metadata_path, \"r\") as f:\n",
+    "        stored_hash = f.read().strip()\n",
+    "    return current_hash != stored_hash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c79f38e4-c011-4249-926a-6aa8ea4a712d",
+   "metadata": {},
+   "source": [
+    "## Extract Tables, Figures, and Markdown using Docling\n",
+    "\n",
+    "This function sets up and runs the full Docling document conversion pipeline:\n",
+    "- Configures `PdfPipelineOptions` for layout, table, and figure detection.\n",
+    "- Saves output in three folders:\n",
+    "  - Extracted tables as CSVs \n",
+    "  - Extracted figures as PNGs\n",
+    "  - Full document markdown\n",
+    "- All outputs are automatically saved to the following directories:\n",
+    "  - `data/output/ExtractedTables`\n",
+    "  - `data/output/ExtractedFigures`\n",
+    "  - `data/output/ExtractedMarkdown`\n",
+    "- These directories are created automatically if they do not already exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1e3a360-0507-43e6-968e-414bf7736c40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_data_with_docling(input_path, output_base=\"data/output\", force=False):\n",
+    "    tables_dir = Path(output_base) / \"ExtractedTables\"\n",
+    "    figures_dir = Path(output_base) / \"ExtractedFigures\"\n",
+    "    markdown_dir = Path(output_base) / \"ExtractedMarkdown\"\n",
+    "\n",
+    "    # Create output directories\n",
+    "    tables_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    figures_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    markdown_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    base_name = Path(input_path).stem\n",
+    "    markdown_path = markdown_dir / f\"{base_name}.md\"\n",
+    "    metadata_path = markdown_dir / f\"{base_name}.md.sha256\"\n",
+    "\n",
+    "    # Check if reprocessing is needed\n",
+    "    reprocess = needs_reprocessing(input_path, metadata_path, force=force)\n",
+    "\n",
+    "    if reprocess:\n",
+    "        print(f\"Processing {input_path}...\")\n",
+    "\n",
+    "        # Set up pipeline options\n",
+    "        pipeline_options = PdfPipelineOptions(\n",
+    "            do_table_structure=True,\n",
+    "            do_figure_detection=True,\n",
+    "            images_scale=2.0,\n",
+    "            generate_page_images=True,\n",
+    "            generate_picture_images=True\n",
+    "        )\n",
+    "        pipeline_options.table_structure_options.mode = TableFormerMode.ACCURATE\n",
+    "        pipeline_options.accelerator_options = AcceleratorOptions(device=AcceleratorDevice.CUDA) #Remove this line if you are not using a GPU\n",
+    "\n",
+    "        # Convert Input to Docling Document for Processing\n",
+    "        doc_converter = DocumentConverter(\n",
+    "            allowed_formats=[InputFormat.PDF, InputFormat.IMAGE],\n",
+    "            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}\n",
+    "        )\n",
+    "        result = doc_converter.convert(input_path)\n",
+    "\n",
+    "        # Save markdown\n",
+    "        markdown_text = result.document.export_to_markdown()\n",
+    "        with open(markdown_path, \"w\", encoding=\"utf-8\") as f:\n",
+    "            f.write(markdown_text)\n",
+    "        print(f\"Saved markdown → {markdown_path}\")\n",
+    "\n",
+    "        # Save file hash\n",
+    "        with open(metadata_path, \"w\") as f:\n",
+    "            f.write(compute_file_hash(input_path))\n",
+    "\n",
+    "        # Save tables\n",
+    "        for table_ix, table in enumerate(result.document.tables):\n",
+    "            df = table.export_to_dataframe()\n",
+    "            table_path = tables_dir / f\"{base_name}-table-{table_ix+1}.csv\"\n",
+    "            df.to_csv(table_path, index=False)\n",
+    "            print(f\"Saved table {table_ix+1} → {table_path}\")\n",
+    "\n",
+    "        # Extract figures using iterate_items and get_image\n",
+    "        from docling_core.types.doc import PictureItem\n",
+    "        pic_count = 0\n",
+    "        for element, _ in result.document.iterate_items():\n",
+    "            if isinstance(element, PictureItem):\n",
+    "                pic_count += 1\n",
+    "                img = element.get_image(result.document)\n",
+    "                fn = f\"{base_name}-figure-{pic_count}.png\"\n",
+    "                fig_path = Path(figures_dir)/fn\n",
+    "                img.save(fig_path, \"PNG\")\n",
+    "                print(f\"Saved figure {pic_count} → {fig_path}\")\n",
+    "\n",
+    "    else:\n",
+    "        print(f\"Skipping extraction for {input_path} — outputs are up to date.\")\n",
+    "\n",
+    "        # Log existing outputs\n",
+    "        if markdown_path.exists():\n",
+    "            print(f\"Existing markdown → {markdown_path}\")\n",
+    "        existing_tables = sorted(tables_dir.glob(f\"{base_name}-table-*.csv\"))\n",
+    "        for i, table_file in enumerate(existing_tables, 1):\n",
+    "            print(f\"Existing table {i} → {table_file}\")\n",
+    "        existing_figures = sorted(figures_dir.glob(f\"{base_name}-figure-*.png\"))\n",
+    "        for i, fig_file in enumerate(existing_figures, 1):\n",
+    "            print(f\"Existing figure {i} → {fig_file}\")\n",
+    "\n",
+    "    # Always print markdown content\n",
+    "    if markdown_path.exists():\n",
+    "        print(\"\\nMarkdown Output:\\n\")\n",
+    "        with open(markdown_path, \"r\", encoding=\"utf-8\") as f:\n",
+    "            print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e57e0ce-51b1-4b83-8724-a9e0ba858b1f",
+   "metadata": {},
+   "source": [
+    "## Display Extracted Tables\n",
+    "\n",
+    "This function loads and displays all CSV files corresponding to the input file’s extracted tables.\n",
+    "\n",
+    "- It finds all the extracted tables\n",
+    "- Loads each table using `pandas`\n",
+    "- Displays them inline for quick verification\n",
+    "\n",
+    "Use this after extraction to verify that tables were parsed and saved correctly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d72855a3-1ddc-4cc4-9907-86cd03d1f266",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_extracted_tables(file_path, tables_base=\"data/output/ExtractedTables\"):\n",
+    "\n",
+    "    base_stem = Path(file_path).stem\n",
+    "    print(\"Extracted Tables:\\n\")\n",
+    "    \n",
+    "    matching_tables = sorted(glob.glob(f\"{tables_base}/{base_stem}-table-*.csv\"))\n",
+    "    if not matching_tables:\n",
+    "        print(\"No tables found.\")\n",
+    "    for csv_file in matching_tables:\n",
+    "        print(f\"Showing: {csv_file}\")\n",
+    "        df = pd.read_csv(csv_file)\n",
+    "        display(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "750074ef-c073-4bf4-9617-1a354a19d440",
+   "metadata": {},
+   "source": [
+    "## Display Extracted Figures\n",
+    "\n",
+    "This function visualizes the figures extracted from the input file:\n",
+    "- Searches for saved `.png` images in the output figures directory.\n",
+    "- Displays each one using `matplotlib`.\n",
+    "\n",
+    "This is helpful for reviewing whether the figure detection and cropping steps worked as intended.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33a33f83-5382-4545-9968-945b965012aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_extracted_figures(file_path, figures_base=\"data/output/ExtractedFigures\"):\n",
+    "\n",
+    "    base_stem = Path(file_path).stem\n",
+    "    print(\"\\nExtracted Figures:\\n\")\n",
+    "    \n",
+    "    matching_figures = sorted(glob.glob(f\"{figures_base}/{base_stem}-figure-*.png\"))\n",
+    "    if not matching_figures:\n",
+    "        print(\"No figures found.\")\n",
+    "    for img_path in matching_figures:\n",
+    "        print(f\"Showing: {img_path}\")\n",
+    "        img = Image.open(img_path)\n",
+    "        plt.figure(figsize=(10, 6))\n",
+    "        plt.imshow(img)\n",
+    "        plt.axis('off')\n",
+    "        plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c61ce453-b47a-4615-8240-8d5ff022f0ad",
+   "metadata": {},
+   "source": [
+    "## Run Extraction on Your File\n",
+    "\n",
+    "This block defines the input file path, displays the document, and prints the markdown output:\n",
+    "- `display_file()` previews the document visually.\n",
+    "- `extract_data_with_docling()` parses it into structured markdown, tables, and figures.\n",
+    "\n",
+    "Set the `input_file` variable to the full path of your PDF file (e.g., `\"mydocs/report.pdf\"`).\n",
+    "\n",
+    "Reprocessing can be forced by setting the force flag to True (e.g., `extract_data_with_docling(input_file,force=True)`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04f44b0e-d12c-4411-8744-7799ea1a60a2",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "input_file = \"path/to/your/input.pdf\"\n",
+    "display_file(input_file)\n",
+    "extract_data_with_docling(input_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62f65ac5-8970-4404-83e8-e4baf1f6bf53",
+   "metadata": {},
+   "source": [
+    "## View Extracted Tables and Figures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3b10536-4bd1-4450-b02a-53b95aa3623d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "display_extracted_tables(input_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "340ad3ef-1de7-4dca-afa2-72ddce6577a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_extracted_figures(input_file)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Docling GPU)",
+   "language": "python",
+   "name": "docenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/DoclingExtract/README.md
+++ b/DoclingExtract/README.md
@@ -1,0 +1,64 @@
+<h1>Project: Document Extraction with Docling</h1>
+
+- [1. Project Description](#1-project-description)
+- [2. Prerequisites](#2-prerequisites)
+- [3. Start CoreAI](#3-start-coreai)
+- [4. Access CoreAI](#4-access-coreai)
+- [5. Required Libraries](#5-required-libraries)
+- [6. Stop CoreAI](#6-stop-coreai)
+- [7. Cleanup](#7-cleanup)
+
+
+# 1. Project Description
+
+This notebook demonstrates an end-to-end pipeline for extracting structured information from PDF and image documents using the **Docling** framework. It automatically detects and extracts:
+
+- Tables (as structured CSV files)
+- Figures (as cropped PNGs)
+- Document text (as clean Markdown)
+
+# 2. Prerequisites
+
+- CPU (It is recommended to use a GPU for significantly faster processing.)
+- Docker or Podman
+
+# 3. Start CoreAI
+
+From the folder where this `README.md` is, run:
+
+```bash
+# Run one of the following commands:
+
+# podman command
+podman run --rm -it --userns=keep-id --device nvidia.com/gpu=all -e WANTED_UID=`id -u` -e WANTED_GID=`id -g` -e CoreAI_VERBOSE="yes" -v `pwd`:/iti -p 8888:8888 docker.io/infotrend/coreai:latest  /run_jupyter.sh
+
+# docker command
+docker run --rm -it --runtime=nvidia --gpus all -e WANTED_UID=`id -u` -e WANTED_GID=`id -g` -e CoreAI_VERBOSE="yes" -v `pwd`:/iti -p 8888:8888 docker.io/infotrend/coreai:latest  /run_jupyter.sh
+```
+
+# 4. Access CoreAI
+
+After the container is started, you can access CoreAI at `http://localhost:8888`.
+
+The Jupyter Lab password is `iti`.
+
+Load the notebook `ExtractionDocling.ipynb` and follow the instructions contained in it.
+
+# 5. Required Libraries
+
+- docling[vlm]
+- pdf2image
+- PyMuPDF
+
+
+All the required libraries are present in the `requirements.txt`
+
+# 6. Stop CoreAI
+
+You can stop the Notebook by using the `File -> Shutdown` option.
+
+Alternatively, you can stop the container by pressing `Ctrl + C` in the terminal where the container is running.
+
+# 7. Cleanup
+
+Because we used the `--rm` flag, the container will be automatically removed when you stop it.

--- a/DoclingExtract/requirements.txt
+++ b/DoclingExtract/requirements.txt
@@ -1,0 +1,3 @@
+docling[vlm]
+pdf2image
+PyMuPDF


### PR DESCRIPTION
This notebook demonstrates an end-to-end pipeline for extracting structured information from PDF and image documents using the Docling framework. It automatically detects and extracts:

Tables (as structured CSV files)
Figures (as cropped PNGs)
Document text (as clean Markdown)

The notebook, it's requirements, and accompanying ReadMe have been added here.